### PR TITLE
Import fix

### DIFF
--- a/omxdsm/cmd.py
+++ b/omxdsm/cmd.py
@@ -4,7 +4,7 @@ A console script wrapper for multiple openmdao functions.
 from __future__ import print_function
 
 import openmdao.utils.hooks as hooks
-from openmdao_xdsm.xdsm_writer import write_xdsm, \
+from omxdsm.xdsm_writer import write_xdsm, \
     _DEFAULT_BOX_STACKING, _DEFAULT_BOX_WIDTH, _MAX_BOX_LINES, _DEFAULT_OUTPUT_SIDE, _CHAR_SUBS
 from openmdao.utils.file_utils import _load_and_exec
 

--- a/omxdsm/cmd.py
+++ b/omxdsm/cmd.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import openmdao.utils.hooks as hooks
 from omxdsm.xdsm_writer import write_xdsm, \
     _DEFAULT_BOX_STACKING, _DEFAULT_BOX_WIDTH, _MAX_BOX_LINES, _DEFAULT_OUTPUT_SIDE, _CHAR_SUBS
-from openmdao.utils.file_utils import _load_and_exec
+from openmdao.utils.file_utils import _load_and_exec, _to_filename
 
 
 def _xdsm_setup_parser(parser):
@@ -79,7 +79,7 @@ def _xdsm_cmd(options, user_args):
     user_args : list of str
         Command line options after '--' (if any).  Passed to user script.
     """
-    filename = options.file[0]
+    filename = _to_filename(options.file[0])
 
     kwargs = {}
     for name in ['box_stacking', 'box_width', 'box_lines', 'numbered_comps', 'number_alignment']:
@@ -106,10 +106,10 @@ def _xdsm_cmd(options, user_args):
 
         hooks._register_hook('setup', 'Problem', post=_xdsm)
 
-        _load_and_exec(filename, user_args)
+        _load_and_exec(options.file[0], user_args)
     else:
         # assume the file is a recording, run standalone
-        write_xdsm(filename, filename=options.outfile, model_path=options.model_path,
+        write_xdsm(options.file[0], filename=options.outfile, model_path=options.model_path,
                    recurse=options.recurse,
                    include_external_outputs=not options.no_extern_outputs,
                    out_format=options.format,

--- a/omxdsm/tests/test_xdsm_viewer.py
+++ b/omxdsm/tests/test_xdsm_viewer.py
@@ -1005,7 +1005,7 @@ class TestXDSMjsViewer(unittest.TestCase):
 class TestCustomXDSMViewer(unittest.TestCase):
 
     def test_custom_writer(self):
-        from openmdao_xdsm.xdsm_writer import XDSMjsWriter
+        from omxdsm.xdsm_writer import XDSMjsWriter
 
         class CustomWriter(XDSMjsWriter):
             """Customized XDSM writer, based on the XDSMjs writer."""

--- a/omxdsm/xdsm_writer.py
+++ b/omxdsm/xdsm_writer.py
@@ -27,7 +27,7 @@ from openmdao.core.problem import Problem
 from openmdao.utils.general_utils import simple_warning
 from openmdao.utils.webview import webview
 from openmdao.visualization.n2_viewer.n2_viewer import _get_viewer_data
-from openmdao.visualization.xdsm_viewer.html_writer import write_html
+from omxdsm.html_writer import write_html
 
 _DIR = os.path.dirname(os.path.abspath(__file__))
 _XDSMJS_PATH = os.path.join(_DIR, 'XDSMjs')


### PR DESCRIPTION
- I tried out the plugin on OpenMDAO version 3 and found a few imports that were failing.
- I also updated it to allow `openmdao xdsm_plugin` to be run directly on a test (not super important, but sometimes handy when debugging tests).
- I didn't change this, but would recommend changing the name of the command from `xdsm_plugin` to `xdsm` since there is no longer any xdsm command built in to OpenMDAO to conflict with it.